### PR TITLE
[cord-api-v2] Add a service account

### DIFF
--- a/charts/cord-api-v2/Chart.yaml
+++ b/charts/cord-api-v2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0.0-rc.1"
 description: Authentication and authorization service for Cord Tools
 name: cord-api-v2
-version: "1.0.0-rc.2"
+version: "1.0.0-rc.3"
 icon: https://irp.cdn-website.com/27aeb91f/dms3rep/multi/Cord-Logo-Stacked-57x57.png
 home: https://github.com/cord-tools/helm-charts
 sources:

--- a/charts/cord-api-v2/README.md
+++ b/charts/cord-api-v2/README.md
@@ -1,6 +1,6 @@
 # cord-api-v2
 
-![Version: 1.0.0-rc.2](https://img.shields.io/badge/Version-1.0.0--rc.2-informational?style=flat-square) ![AppVersion: 1.0.0-rc.1](https://img.shields.io/badge/AppVersion-1.0.0--rc.1-informational?style=flat-square)
+![Version: 1.0.0-rc.3](https://img.shields.io/badge/Version-1.0.0--rc.3-informational?style=flat-square) ![AppVersion: 1.0.0-rc.1](https://img.shields.io/badge/AppVersion-1.0.0--rc.1-informational?style=flat-square)
 
 Authentication and authorization service for Cord Tools
 
@@ -74,5 +74,8 @@ helm repo add cord-tools https://cord-tools.github.io/helm-charts
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | tolerations | list | `[]` |  |

--- a/charts/cord-api-v2/templates/_helpers.tpl
+++ b/charts/cord-api-v2/templates/_helpers.tpl
@@ -59,3 +59,10 @@ app.kubernetes.io/name: {{ include "cord-api-v2.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{- define "cord-api-v2.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cord-api-v2.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/cord-api-v2/templates/deployment.yaml
+++ b/charts/cord-api-v2/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         {{- include "cord-api-v2.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "cord-api-v2.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/cord-api-v2/templates/serviceaccount.yaml
+++ b/charts/cord-api-v2/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cord-api-v2.serviceAccountName" . }}
+  labels:
+    {{- include "cord-api-v2.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/cord-api-v2/values.yaml
+++ b/charts/cord-api-v2/values.yaml
@@ -139,6 +139,15 @@ tolerations: []
 
 affinity: {}
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 postgresql:
   enabled: true
   postgresqlDatabase: cordtools


### PR DESCRIPTION
This will allow setting an IAM role for service accounts (IRSA) to give permission for SES or anything else in AWS.