### PR TITLE
[cord-api-v2] Update the command to generate an RSA private key

### DIFF
--- a/charts/cord-api-v2/Chart.yaml
+++ b/charts/cord-api-v2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0.0-rc.1"
 description: Authentication and authorization service for Cord Tools
 name: cord-api-v2
-version: "1.0.0-rc.3"
+version: "1.0.0-rc.4"
 icon: https://irp.cdn-website.com/27aeb91f/dms3rep/multi/Cord-Logo-Stacked-57x57.png
 home: https://github.com/cord-tools/helm-charts
 sources:

--- a/charts/cord-api-v2/README.md
+++ b/charts/cord-api-v2/README.md
@@ -1,6 +1,6 @@
 # cord-api-v2
 
-![Version: 1.0.0-rc.3](https://img.shields.io/badge/Version-1.0.0--rc.3-informational?style=flat-square) ![AppVersion: 1.0.0-rc.1](https://img.shields.io/badge/AppVersion-1.0.0--rc.1-informational?style=flat-square)
+![Version: 1.0.0-rc.4](https://img.shields.io/badge/Version-1.0.0--rc.4-informational?style=flat-square) ![AppVersion: 1.0.0-rc.1](https://img.shields.io/badge/AppVersion-1.0.0--rc.1-informational?style=flat-square)
 
 Authentication and authorization service for Cord Tools
 

--- a/charts/cord-api-v2/values.yaml
+++ b/charts/cord-api-v2/values.yaml
@@ -70,7 +70,8 @@ secrets:
   # AZURE_CLIENT_SECRET: ""
 
   # Private key to sign JWTs with
-  # can be generated with: ssh-keygen -t rsa -b 4096 -f key-name.key
+  # can be generated with: openssl genrsa -out <key-name.key> <bit-size>
+  # e.g. openssl genrsa -out cordtools-jwt.key 4096
   JWT_SIGNING_KEY: "changeme"
 
   # 64 character random string


### PR DESCRIPTION
On a Mac the other command doesn't generate the correct type of key causing an error in cord-api-v2.