### PR TITLE
[cord-stack] Update the command to generate an RSA private key

### DIFF
--- a/charts/cord-stack/Chart.lock
+++ b/charts/cord-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.0-rc.9
 - name: cord-api-v2
   repository: https://cord-tools.github.io/helm-charts
-  version: 1.0.0-rc.3
+  version: 1.0.0-rc.4
 - name: cord-ui
   repository: https://cord-tools.github.io/helm-charts
   version: 1.0.0-rc.4
@@ -17,5 +17,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 13.3.0
-digest: sha256:47116e668b8a934f4d3727c3ab07ca7bfc167c1513fd5a16f1be2f31adb5a336
-generated: "2021-10-05T13:22:49.274125-06:00"
+digest: sha256:e312237f85bfa61fa93db1baf175c0373cbbfcbebffd56a64486ffb65f937c82
+generated: "2021-10-27T17:26:05.90581885-06:00"

--- a/charts/cord-stack/Chart.yaml
+++ b/charts/cord-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The fullstack of Cord Tools
 name: cord-stack
-version: "1.0.0-rc.10"
+version: "1.0.0-rc.11"
 icon: https://irp.cdn-website.com/27aeb91f/dms3rep/multi/Cord-Logo-Stacked-57x57.png
 home: https://github.com/cord-tools/helm-charts
 sources:
@@ -16,7 +16,7 @@ dependencies:
     condition: cord-api.enabled
     repository: https://cord-tools.github.io/helm-charts
   - name: cord-api-v2
-    version: "1.0.0-rc.3"
+    version: "1.0.0-rc.4"
     condition: cord-api-v2.enabled
     repository: https://cord-tools.github.io/helm-charts
   - name: cord-ui

--- a/charts/cord-stack/README.md
+++ b/charts/cord-stack/README.md
@@ -1,6 +1,6 @@
 # cord-stack
 
-![Version: 1.0.0-rc.10](https://img.shields.io/badge/Version-1.0.0--rc.10-informational?style=flat-square)
+![Version: 1.0.0-rc.11](https://img.shields.io/badge/Version-1.0.0--rc.11-informational?style=flat-square)
 
 The fullstack of Cord Tools
 
@@ -13,7 +13,7 @@ The fullstack of Cord Tools
 | Repository | Name | Version |
 |------------|------|---------|
 | https://cord-tools.github.io/helm-charts | cord-api | 1.0.0-rc.9 |
-| https://cord-tools.github.io/helm-charts | cord-api-v2 | 1.0.0-rc.3 |
+| https://cord-tools.github.io/helm-charts | cord-api-v2 | 1.0.0-rc.4 |
 | https://cord-tools.github.io/helm-charts | cord-proxy | 1.0.0-rc.3 |
 | https://cord-tools.github.io/helm-charts | cord-ui | 1.0.0-rc.4 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | ~3.22.0 |

--- a/charts/cord-stack/values.yaml
+++ b/charts/cord-stack/values.yaml
@@ -225,7 +225,8 @@ cord-api-v2:
     # AZURE_CLIENT_SECRET: ""
 
     # Private key to sign JWTs with
-    # can be generated with: ssh-keygen -t rsa -b 4096 -f key-name.key
+    # can be generated with: openssl genrsa -out <key-name.key> <bit-size>
+    # e.g. openssl genrsa -out cordtools-jwt.key 4096
     JWT_SIGNING_KEY: |-
       changeme
 


### PR DESCRIPTION
On a Mac the other command doesn't generate the correct type of key causing an error in cord-api-v2.