### PR TITLE
[cord-api] Include cordtools pod labels in the metrics for AEM

### DIFF
--- a/charts/cord-api/Chart.yaml
+++ b/charts/cord-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0.0-rc.6"
 description: The API for Cord Tools
 name: cord-api
-version: "1.0.0-rc.10"
+version: "1.0.0-rc.11"
 icon: https://irp.cdn-website.com/27aeb91f/dms3rep/multi/Cord-Logo-Stacked-57x57.png
 home: https://github.com/cord-tools/helm-charts
 sources:

--- a/charts/cord-api/README.md
+++ b/charts/cord-api/README.md
@@ -1,6 +1,6 @@
 # cord-api
 
-![Version: 1.0.0-rc.10](https://img.shields.io/badge/Version-1.0.0--rc.10-informational?style=flat-square) ![AppVersion: 1.0.0-rc.6](https://img.shields.io/badge/AppVersion-1.0.0--rc.6-informational?style=flat-square)
+![Version: 1.0.0-rc.11](https://img.shields.io/badge/Version-1.0.0--rc.11-informational?style=flat-square) ![AppVersion: 1.0.0-rc.6](https://img.shields.io/badge/AppVersion-1.0.0--rc.6-informational?style=flat-square)
 
 The API for Cord Tools
 

--- a/charts/cord-api/templates/servicemonitor-aem.yaml
+++ b/charts/cord-api/templates/servicemonitor-aem.yaml
@@ -14,4 +14,8 @@ spec:
   endpoints:
     - port: prometheus-metrics
       interval: 1m
+  podTargetLabels:
+    - cordToolsAccount
+    - cordToolsEnvironment
+    - cordToolsInstanceType
 {{- end }}


### PR DESCRIPTION
Closes CORD-683.