### PR TITLE
Updated Mongo chart to 13.9.0

### DIFF
--- a/charts/cord-api/Chart.lock
+++ b/charts/cord-api/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mongodb
-  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-  version: 10.5.2
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.9.4
 - name: loki
   repository: https://grafana.github.io/helm-charts
   version: 2.3.0
 - name: promtail
   repository: https://grafana.github.io/helm-charts
   version: 3.0.5
-digest: sha256:5c5fe9f1af265872b432c79dc2209410876777bdd77a3af701f4ac0274e86efd
-generated: "2023-03-14T16:01:48.283126-06:00"
+digest: sha256:b156cf404042491c1db057b8fe9201ae12fa8518cc99ad745e021b60242a1c1d
+generated: "2023-04-06T09:59:35.4401-06:00"

--- a/charts/cord-api/Chart.yaml
+++ b/charts/cord-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.1.8"
 description: The API for Cord Tools
 name: cord-api
-version: "1.2.2"
+version: "1.2.3"
 icon: https://irp.cdn-website.com/27aeb91f/dms3rep/multi/Cord-Logo-Stacked-57x57.png
 home: https://github.com/cord-tools/helm-charts
 sources:
@@ -13,9 +13,9 @@ maintainers:
     email: help@cord.tools
 dependencies:
   - name: mongodb
-    version: "~10.5.2"
+    version: "~13.9.0"
     condition: mongodb.enabled
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    repository: https://charts.bitnami.com/bitnami
   - name: "loki"
     version: "~2.3.0"
     condition: loki.enabled

--- a/charts/cord-api/README.md
+++ b/charts/cord-api/README.md
@@ -1,6 +1,6 @@
 # cord-api
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: 1.1.8](https://img.shields.io/badge/AppVersion-1.1.8-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: 1.1.8](https://img.shields.io/badge/AppVersion-1.1.8-informational?style=flat-square)
 
 The API for Cord Tools
 
@@ -12,9 +12,9 @@ The API for Cord Tools
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.bitnami.com/bitnami | mongodb | ~13.9.0 |
 | https://grafana.github.io/helm-charts | loki | ~2.3.0 |
 | https://grafana.github.io/helm-charts | promtail | ~3.0.4 |
-| https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami | mongodb | ~10.5.2 |
 
 ## Chart Repo
 


### PR DESCRIPTION
This PR is blocked by the upgrade on the API.

This upgrade changes the Mongo version to Mongo6.0 and the library we are currently using to communicate doesn't support that version.

Please leave this PR open for now.